### PR TITLE
Improve aquarium add UX

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,6 +46,8 @@ const extraRegisterFields = document.getElementById('extra-register-fields');
 const aquariumSelect = document.getElementById('aquarium-select');
 const addAquariumBtn = document.getElementById('add-aquarium');
 const deleteAquariumBtn = document.getElementById('delete-aquarium');
+const newAquariumInput = document.getElementById('new-aquarium-name');
+const saveAquariumBtn = document.getElementById('save-aquarium');
 
 let isRegister = false;
 let currentUserData = null;
@@ -517,25 +519,39 @@ aquariumSelect.addEventListener('change', () => {
   deleteAquariumBtn.classList.toggle('hidden', aquariumSelect.options.length <= 1);
 });
 
-addAquariumBtn.addEventListener('click', async () => {
+addAquariumBtn.addEventListener('click', () => {
+  newAquariumInput.classList.toggle('hidden');
+  saveAquariumBtn.classList.toggle('hidden');
+  if (!newAquariumInput.classList.contains('hidden')) {
+    newAquariumInput.focus();
+  }
+});
+
+saveAquariumBtn.addEventListener('click', async () => {
   const user = auth.currentUser;
   if (!user) return;
-  const name = prompt('Aquarium name:');
+  const name = newAquariumInput.value.trim();
   if (!name) return;
-  const docRef = await addDoc(collection(db, `users/${user.uid}/aquariums`), { name });
-  // Initialize measurements subcollection so it exists immediately
-  await setDoc(doc(db, `users/${user.uid}/aquariums/${docRef.id}/measurements`, 'init'), { init: true, timestamp: new Date() });
+  try {
+    const docRef = await addDoc(collection(db, `users/${user.uid}/aquariums`), { name });
+    await setDoc(doc(db, `users/${user.uid}/aquariums/${docRef.id}/measurements`, 'init'), { init: true, timestamp: new Date() });
 
-  // Immediately update the dropdown for better UX
-  const opt = document.createElement('option');
-  opt.value = docRef.id;
-  opt.textContent = name;
-  aquariumSelect.appendChild(opt);
-  aquariumSelect.value = docRef.id;
-  currentAquariumId = docRef.id;
-  deleteAquariumBtn.classList.toggle('hidden', aquariumSelect.options.length <= 1);
+    const opt = document.createElement('option');
+    opt.value = docRef.id;
+    opt.textContent = name;
+    aquariumSelect.appendChild(opt);
+    aquariumSelect.value = docRef.id;
+    currentAquariumId = docRef.id;
+    deleteAquariumBtn.classList.toggle('hidden', aquariumSelect.options.length <= 1);
 
-  loadData(user.uid);
+    newAquariumInput.value = '';
+    newAquariumInput.classList.add('hidden');
+    saveAquariumBtn.classList.add('hidden');
+
+    loadData(user.uid);
+  } catch (err) {
+    alert('Failed to add aquarium: ' + err.message);
+  }
 });
 
 deleteAquariumBtn.addEventListener('click', async () => {

--- a/index.html
+++ b/index.html
@@ -401,6 +401,8 @@
         <label for="aquarium-select" class="text-sm font-medium text-blue-900">Aquarium:</label>
         <select id="aquarium-select" class="aquarium-select flex-grow"></select>
         <button id="add-aquarium" type="button" class="px-2 py-1 bg-blue-200 rounded-full text-blue-800">Add</button>
+        <input id="new-aquarium-name" type="text" placeholder="Name" class="hidden border border-blue-300 rounded-full px-2 py-1 text-sm" />
+        <button id="save-aquarium" type="button" class="hidden px-2 py-1 bg-blue-200 rounded-full text-blue-800">Save</button>
         <button id="delete-aquarium" type="button" class="px-2 py-1 bg-red-200 rounded-full text-red-800 hidden">Delete</button>
       </div>
       <form id="data-form" class="grid gap-3 mb-6" autocomplete="off" novalidate>


### PR DESCRIPTION
## Summary
- add text input for new aquariums
- handle aquarium creation with a custom button instead of `prompt`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684a980b2ce48323a784910594ed1cac