### PR TITLE
Fix aquarium init doc creation

### DIFF
--- a/app.js
+++ b/app.js
@@ -190,6 +190,7 @@ async function loadAquariums(uid, selectId = null) {
 
   if (!firstId) {
     const docRef = await addDoc(collection(db, `users/${uid}/aquariums`), { name: 'My Aquarium' });
+    await setDoc(doc(db, `users/${uid}/aquariums/${docRef.id}/measurements`, 'init'), { init: true, timestamp: new Date() });
     firstId = docRef.id;
     const opt = document.createElement('option');
     opt.value = firstId;


### PR DESCRIPTION
## Summary
- ensure an initial `measurements/init` document is created when the first aquarium is auto-created

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a99842fec83238f0ca3119127519d