### PR TITLE
Improve testing reminders UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -550,17 +550,23 @@ function updateReminders(measurements) {
   const now = new Date();
   for (const key in testFrequencies) {
     const li = document.createElement('li');
+    li.classList.add('col-span-1');
     const lastDate = lastDates[key];
     const freq = testFrequencies[key];
     let text;
     if (!lastDate) {
       text = `${testLabels[key]}: test today`;
+      li.classList.add('text-green-600', 'font-semibold');
     } else {
       const daysSince = Math.floor((now - lastDate) / (1000 * 60 * 60 * 24));
       const daysLeft = freq - daysSince;
-      text = daysLeft <= 0 ?
-        `${testLabels[key]}: test today` :
-        `${testLabels[key]}: in ${daysLeft} day${daysLeft === 1 ? '' : 's'}`;
+      if (daysLeft <= 0) {
+        text = `${testLabels[key]}: test today`;
+        li.classList.add('text-green-600', 'font-semibold');
+      } else {
+        text = `${testLabels[key]}: in ${daysLeft} day${daysLeft === 1 ? '' : 's'}`;
+        li.classList.add('text-black');
+      }
     }
     li.textContent = text;
     reminderList.appendChild(li);

--- a/index.html
+++ b/index.html
@@ -416,6 +416,10 @@
         <button id="save-aquarium" type="button" class="hidden px-2 py-1 bg-blue-200 rounded-full text-blue-800 w-full sm:w-auto">Save</button>
         <button id="delete-aquarium" type="button" class="px-2 py-1 bg-red-200 rounded-full text-red-800 hidden w-full sm:w-auto">Delete</button>
       </div>
+      <div id="reminder-box" class="bg-blue-50 rounded-xl p-4 text-sm text-gray-900 max-w-xl mx-auto mt-2 mb-4">
+        <h3 class="text-lg font-semibold mb-2 text-blue-800">Testing Reminders</h3>
+        <ul id="reminder-list" class="grid grid-cols-2 gap-x-4 gap-y-1"></ul>
+      </div>
       <form id="data-form" class="grid gap-3 mb-6" autocomplete="off" novalidate>
         <div class="grid grid-cols-2 gap-2 text-gray-700 text-xs font-semibold">
           <label for="ph" class="flex items-center gap-1"><span>pH</span><span>(unitless)</span></label>
@@ -466,10 +470,6 @@
         </div>
       </div>
 
-      <div id="reminder-box" class="bg-blue-50 rounded-xl p-4 text-sm text-blue-900 max-w-xl mx-auto mt-6">
-        <h3 class="text-lg font-semibold mb-2 text-blue-800">Testing Reminders</h3>
-        <ul id="reminder-list" class="space-y-1"></ul>
-      </div>
 
       <div id="detail-view" class="mt-6 hidden bg-white p-4 rounded-xl shadow text-sm text-gray-900 max-w-xl mx-auto">
         <h4 class="font-bold mb-2">Measurement Detail</h4>


### PR DESCRIPTION
## Summary
- move the testing reminders block below the aquarium selector
- show reminders in two columns with grid layout
- highlight tests due today in green
- use black text for other reminders

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684aa26bee208323ae05132a91580281