### PR TITLE
Enhance testing reminders with glass style

### DIFF
--- a/app.js
+++ b/app.js
@@ -550,7 +550,7 @@ function updateReminders(measurements) {
   const now = new Date();
   for (const key in testFrequencies) {
     const li = document.createElement('li');
-    li.classList.add('col-span-1');
+    li.classList.add('col-span-1', 'glass', 'rounded-lg', 'px-2', 'py-1');
     const lastDate = lastDates[key];
     const freq = testFrequencies[key];
     let text;

--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@
         <button id="save-aquarium" type="button" class="hidden px-2 py-1 bg-blue-200 rounded-full text-blue-800 w-full sm:w-auto">Save</button>
         <button id="delete-aquarium" type="button" class="px-2 py-1 bg-red-200 rounded-full text-red-800 hidden w-full sm:w-auto">Delete</button>
       </div>
-      <div id="reminder-box" class="bg-blue-200 rounded-xl p-4 text-sm text-gray-900 w-full mx-auto mt-2 mb-4 border-l-4 border-blue-400">
+      <div id="reminder-box" class="glass rounded-xl p-4 text-sm text-gray-900 w-full mx-auto mt-2 mb-4 border-l-4 border-blue-400">
         <h3 class="text-lg font-semibold mb-2 text-blue-800">Testing Reminders</h3>
         <ul id="reminder-list" class="grid grid-cols-2 gap-x-4 gap-y-1"></ul>
       </div>


### PR DESCRIPTION
## Summary
- update testing reminder container to use glass style
- make each reminder pill glassy for a liquid look

## Testing
- `node app.js` *(fails: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader)*

------
https://chatgpt.com/codex/tasks/task_e_684aa50b47988323b6b14fe697142d09