### PR TITLE
Add measurement unit explanations box

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,15 +420,25 @@
         <h3 class="text-lg font-semibold mb-2 text-blue-800">Testing Reminders</h3>
         <ul id="reminder-list" class="grid grid-cols-2 gap-x-4 gap-y-1"></ul>
       </div>
+
+      <div id="value-explanations" class="bg-blue-50 rounded-md p-2 text-xs text-gray-700 mb-4 grid grid-cols-2 gap-x-4 gap-y-1">
+        <span>pH (unitless)</span>
+        <span>GH (°dH)</span>
+        <span>KH (°dH)</span>
+        <span>Chlorine (mg/L)</span>
+        <span>Nitrite (mg/L)</span>
+        <span>Nitrate (mg/L)</span>
+        <span>Fe2 (mg/L)</span>
+      </div>
       <form id="data-form" class="grid gap-3 mb-6" autocomplete="off" novalidate>
         <div class="grid grid-cols-2 gap-2 text-gray-700 text-xs font-semibold">
-          <label for="ph" class="flex items-center gap-1"><span>pH</span><span>(unitless)</span></label>
-          <label for="gh" class="flex items-center gap-1"><span>GH</span><span>(°dH)</span></label>
-          <label for="kh" class="flex items-center gap-1"><span>KH</span><span>(°dH)</span></label>
-          <label for="chlorine" class="flex items-center gap-1"><span>Chlorine</span><span>(mg/L)</span></label>
-          <label for="nitrite" class="flex items-center gap-1"><span>Nitrite</span><span>(mg/L)</span></label>
-          <label for="nitrate" class="flex items-center gap-1"><span>Nitrate</span><span>(mg/L)</span></label>
-          <label for="fe2" class="flex items-center gap-1"><span>Fe2</span><span>(mg/L)</span></label>
+          <label for="ph" class="flex items-center gap-1"><span>pH</span></label>
+          <label for="gh" class="flex items-center gap-1"><span>GH</span></label>
+          <label for="kh" class="flex items-center gap-1"><span>KH</span></label>
+          <label for="chlorine" class="flex items-center gap-1"><span>Chlorine</span></label>
+          <label for="nitrite" class="flex items-center gap-1"><span>Nitrite</span></label>
+          <label for="nitrate" class="flex items-center gap-1"><span>Nitrate</span></label>
+          <label for="fe2" class="flex items-center gap-1"><span>Fe2</span></label>
         </div>
         <div class="grid grid-cols-2 gap-2">
           <input type="number" step="0.01" id="ph" placeholder="pH" class="border rounded-full px-2 py-1 text-sm" required />


### PR DESCRIPTION
## Summary
- add new `value-explanations` box under reminders with small text size
- remove old unit text from form labels so the information isn't duplicated

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684aa6b731188323b4a45fe2ca034e10