### PR TITLE
Improve nav spacing and safe area

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,22 @@
       justify-content: center;
       padding-top: constant(safe-area-inset-top);
       padding-top: env(safe-area-inset-top);
+    }
+
+    nav::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: constant(safe-area-inset-top);
+      height: env(safe-area-inset-top);
+      background: var(--glass-bg);
+      border-bottom: 1px solid var(--glass-border);
+      backdrop-filter: blur(20px) saturate(180%);
+      -webkit-backdrop-filter: blur(20px) saturate(180%);
+      box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+      z-index: -1;
       }
     #profile-container {
       max-width: 960px;
@@ -75,6 +91,7 @@
       display: flex;
       align-items: center;
       gap: 0.25rem;
+      padding-left: 0.5rem;
       cursor: pointer;
       color: white;
       user-select: none;


### PR DESCRIPTION
## Summary
- add Liquid Glass overlay for the top safe-area
- give profile dropdown some padding to space it from the logo

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684aba624ed8832388443645458bd681