### PR TITLE
Improve readability of value explanations on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,14 +466,14 @@
         <ul id="reminder-list" class="grid grid-cols-2 gap-x-4 gap-y-1"></ul>
       </div>
 
-      <div id="value-explanations" class="bg-blue-50 rounded-md p-2 text-xs text-gray-700 mb-4 grid grid-cols-2 gap-x-4 gap-y-1">
+      <div id="value-explanations" class="bg-blue-50 rounded-md p-2 text-sm text-gray-700 mb-4 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1">
         <span>pH (unitless)</span>
-        <span>GH (°dH)</span>
-        <span>KH (°dH)</span>
-        <span>Chlorine (mg/L)</span>
-        <span>Nitrite (mg/L)</span>
-        <span>Nitrate (mg/L)</span>
-        <span>Fe2 (mg/L)</span>
+        <span>General Hardness (GH, °dH)</span>
+        <span>Carbonate Hardness (KH, °dH)</span>
+        <span>Chlorine (Cl₂, mg/L)</span>
+        <span>Nitrite (NO₂⁻, mg/L)</span>
+        <span>Nitrate (NO₃⁻, mg/L)</span>
+        <span>Iron (Fe²⁺, mg/L)</span>
       </div>
       <form id="data-form" class="grid gap-3 mb-6" autocomplete="off" novalidate>
         <div class="grid grid-cols-2 gap-2">


### PR DESCRIPTION
## Summary
- enlarge value explanation text and use one-column layout on small screens

## Testing
- `node -c app.js`


------
https://chatgpt.com/codex/tasks/task_e_684ac3b98c908323bdbc90e1c8c1364d