### PR TITLE
Split dashboard after save into analysis section

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,7 @@ const toggleLink = document.getElementById('toggle-link');
 const authSubmit = document.getElementById('auth-submit');
 const logoutButton = document.getElementById('logout-button');
 const profileContainer = document.getElementById('profile-container');
+const analysisContainer = document.getElementById('analysis');
 const profileToggle = document.getElementById('profile-name-dropdown');
 const profileDropdown = document.getElementById('profile-dropdown');
 const profileUsername = document.getElementById('profile-username');
@@ -134,6 +135,7 @@ onAuthStateChanged(auth, async (user) => {
   if (user) {
     authContainer.classList.add('hidden');
     dashboard.classList.remove('hidden');
+    analysisContainer.classList.remove('hidden');
     profileContainer.style.display = 'flex';
 
     try {
@@ -153,6 +155,7 @@ onAuthStateChanged(auth, async (user) => {
   } else {
     authContainer.classList.remove('hidden');
     dashboard.classList.add('hidden');
+    analysisContainer.classList.add('hidden');
     profileContainer.style.display = 'none';
     if (profileUsername) profileUsername.textContent = '';
     currentUserData = null;

--- a/index.html
+++ b/index.html
@@ -524,6 +524,9 @@
         </div>
         <button type="submit" class="mt-4">Save</button>
       </form>
+    </section>
+
+    <section id="analysis" class="hidden bg-white rounded-2xl p-4 mt-4">
       <div id="result" class="text-center text-sm text-blue-800 mb-2"></div>
 
       <div id="charts" class="max-w-xl mx-auto mb-6">


### PR DESCRIPTION
## Summary
- separate the dashboard input section from the chart/AI/history area
- toggle visibility of new analysis section with the dashboard

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_684aca828170832393da83b7fbb6046d