### PR TITLE
Apply glass UI theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,15 +6,15 @@
   <title>BubbleLog</title>
   <link rel="apple-touch-icon" href="apple-touch-icon.png">
   <link rel="manifest" href="manifest.json" />
-  <meta name="theme-color" content="#1e3a8a" />
+  <meta name="theme-color" content="#7e22ce" />
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Raleway:wght@700&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
 
     :root {
-      --glass-bg: rgba(255, 255, 255, 0.3);
-      --glass-border: rgba(255, 255, 255, 0.4);
+      --glass-bg: rgba(255, 255, 255, 0.15);
+      --glass-border: rgba(255, 255, 255, 0.3);
     }
 
     .glass {
@@ -27,9 +27,9 @@
 
     body {
       background: radial-gradient(at top left, rgba(255,255,255,0.25), transparent 70%),
-                  linear-gradient(to bottom, #1e3a8a, #2563eb);
-      color: #1f2937;
-      font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+                  linear-gradient(to bottom right, #3b0764, #7e22ce, #a855f7);
+      color: #ffffff;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, Arial, sans-serif;
       min-height: 100vh;
       margin: 0;
       padding-top: calc(56px + constant(safe-area-inset-top));
@@ -77,12 +77,10 @@
       height: calc(100% + env(safe-area-inset-top));
       background: linear-gradient(
         90deg,
-        rgba(0, 24, 72, 0.3),
-        rgba(0, 70, 140, 0.3),
-        rgba(0, 118, 190, 0.3),
-        rgba(0, 180, 216, 0.3),
-        rgba(144, 224, 239, 0.3),
-        rgba(202, 240, 248, 0.3)
+        rgba(80, 16, 88, 0.3),
+        rgba(124, 58, 237, 0.3),
+        rgba(168, 85, 247, 0.3),
+        rgba(196, 104, 255, 0.3)
       );
       z-index: -2;
     }
@@ -95,7 +93,7 @@
       padding: 0.75rem 1rem;
       color: white;
       position: relative;
-      font-family: 'Raleway', sans-serif;
+      font-family: 'Inter', sans-serif;
       font-weight: 700;
       font-size: 1.5rem;
       user-select: none;
@@ -132,7 +130,7 @@
       font-weight: 400;
       font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
       font-size: 0.95rem;
-      color: #1e40af;
+      color: #7e22ce;
       box-shadow: 0 4px 6px rgb(0 0 0 / 0.1);
     }
 
@@ -154,7 +152,7 @@
       margin: 1rem auto 2rem;
       position: relative;
       background: linear-gradient(135deg, rgba(255,255,255,0.4) 0%, rgba(255,255,255,0.1) 100%),
-                  linear-gradient(to right, #1e40af, #3b82f6, #60a5fa);
+                  linear-gradient(to right, #7e22ce, #9333ea, #c084fc);
       border-radius: 1.5rem;
       height: 160px;
       overflow: hidden;
@@ -165,7 +163,7 @@
       color: white;
       text-align: center;
       user-select: none;
-      font-family: 'Raleway', sans-serif;
+      font-family: 'Inter', sans-serif;
       font-weight: 700;
       font-size: 3rem;
       letter-spacing: 0.05em;
@@ -223,12 +221,12 @@
     }
     .edit-btn {
       cursor: pointer;
-      color: #1e40af;
+      color: #7e22ce;
       margin-left: 4px;
       user-select: none;
     }
     .edit-btn:hover {
-      color: #1e3a8a;
+      color: #6b21a8;
     }
     .delete-btn:hover {
       color: #b91c1c;
@@ -240,20 +238,20 @@
 
     button#auth-submit,
     button[type="submit"] {
-      background-color: #2563eb !important;
+      background-color: #9333ea !important;
       color: white !important;
       font-weight: 600;
       border-radius: 9999px;
       padding: 0.5rem 1rem;
       transition: background-color 0.2s ease-in-out;
       box-shadow: none !important;
-      font-family: 'Raleway', sans-serif;
+      font-family: 'Inter', sans-serif;
       width: auto;
       cursor: pointer;
     }
     button#auth-submit:hover,
     button[type="submit"]:hover {
-      background-color: #1e40af !important;
+      background-color: #7e22ce !important;
     }
 
     /* Styled dropdown for aquarium selection */
@@ -261,15 +259,15 @@
       -webkit-appearance: none;
       appearance: none;
       background-color: rgba(255, 255, 255, 0.7);
-      border: 1px solid #93c5fd;
+      border: 1px solid #e9d5ff;
       border-radius: 9999px;
       padding: 0.5rem 2rem 0.5rem 0.75rem;
-      background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%231e3a8a'%3e%3cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M6 9l6 6 6-6'/%3e%3c/svg%3e");
+      background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%237e22ce'%3e%3cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M6 9l6 6 6-6'/%3e%3c/svg%3e");
       background-repeat: no-repeat;
       background-position: right 0.75rem center;
       background-size: 1rem;
       font-weight: 500;
-      color: #1e3a8a;
+      color: #7e22ce;
     }
 
     @media (max-width: 600px) {
@@ -411,12 +409,12 @@
       padding: 0.25rem 0.75rem;
       border-radius: 9999px;
       background-color: #bfdbfe;
-      color: #1e3a8a;
+      color: #7e22ce;
       font-weight: 600;
     }
 
     #aquarium-menu button.active {
-      background-color: #2563eb;
+      background-color: #9333ea;
       color: white;
     }
 
@@ -442,9 +440,9 @@
     <div id="profile-container" role="navigation" aria-label="Main Navigation">
       <div class="logo-font flex items-center gap-2" aria-label="App logo">
         <svg width="32" height="32" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-          <circle cx="20" cy="20" r="10" fill="#3b82f6" />
-          <circle cx="38" cy="26" r="8" fill="#60a5fa" />
-          <circle cx="28" cy="38" r="6" fill="#93c5fd" />
+          <circle cx="20" cy="20" r="10" fill="#a855f7" />
+          <circle cx="38" cy="26" r="8" fill="#c084fc" />
+          <circle cx="28" cy="38" r="6" fill="#e9d5ff" />
         </svg>
         <span class="text-xl font-bold text-white select-none">BubbleLog</span>
       </div>

--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
   "short_name": "BubbleLog",
   "start_url": ".",
   "display": "standalone",
-  "background_color": "#1e3a8a",
-  "theme_color": "#1e3a8a",
+  "background_color": "#7e22ce",
+  "theme_color": "#7e22ce",
   "icons": [
     {
       "src": "apple-touch-icon.png",


### PR DESCRIPTION
## Summary
- adopt Inter font and purple glass styling for new macOS-like look
- update gradients and buttons to purple
- adjust app manifest theme color

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685130085e5c83239f8a1c091fcc5289